### PR TITLE
Propogate fs and framesize through the pipeline

### DIFF
--- a/python/audio_dsp/design/stage.py
+++ b/python/audio_dsp/design/stage.py
@@ -192,7 +192,7 @@ class Stage(Node):
         self.n_out = n_out
         self._o = []
         for i in range(n_out):
-            output = StageOutput()
+            output = StageOutput(fs=self.fs, frame_size=self.frame_size)
             output.source_index = i
             output.set_source(self)
             self._o.append(output)


### PR DESCRIPTION
before this change stages werent setting the output fs and frame_size so they defaulted to 48000 and 1, now they are set so the values propogate