### PR TITLE
Create StageOutputList for convenience

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -10,3 +10,7 @@ check:
 update:
 	ruff check --fix
 	ruff format
+
+dev:
+	make update
+	make check

--- a/python/audio_dsp/design/graph.py
+++ b/python/audio_dsp/design/graph.py
@@ -110,6 +110,7 @@ class Graph(Generic[NodeSubClass]):
 
     def add_edge(self, edge) -> None:
         """Append an edge to this graph."""
+        assert isinstance(edge, Edge)
         if self._locked:
             raise RuntimeError("Cannot add edges to a locked graph")
         self.edges.append(edge)

--- a/python/audio_dsp/design/stage.py
+++ b/python/audio_dsp/design/stage.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from audio_dsp.design import plot
 from audio_dsp.dsp.generic import dsp_block
 from typing import Optional
+from types import NotImplementedType
 
 
 def find_config(name):
@@ -87,6 +88,114 @@ class StageOutput(Edge):
         dest = "-" if self.dest is None else f"{self.dest.index} {self.dest_index}"
         source = "-" if self.source is None else f"{self.source.index} {self.source_index}"
         return f"({source} -> {dest})"
+
+
+class StageOutputList:
+    """
+    A container of StageOutput.
+
+    A stage output list will be created whenever a stage is added to the pipeline.
+    It is unlikely that a StageOutputList will have to be explicitly created during pipeline
+    design. However the indexing and combining methods shown in the example will be used to
+    create new StageOutputList instances.
+
+    Example
+    -------
+    This example shows how to combine StageOutputList in various ways::
+
+        # a and b are StageOutputList
+        a = some_stage.o
+        b = other_stage.o
+
+        # concatenate them
+        a + b
+
+        # Choose a single channel from 'a'
+        a[0]
+
+        # Choose channels 0 and 3 from 'a'
+        a[0, 3]
+
+        # Choose a slice of channels from 'a', start:stop:step
+        a[0:10:2]
+
+        # Combine channels 0 and 3 from 'a', and 2 from 'b'
+        a[0, 3] + b[2]
+
+        # Join 'a' and 'b', with a placeholder "None" in between
+        a + None + b
+
+    Attributes
+    ----------
+    edges : list[StageOutput]
+        To access the actual edges contained within this list then read from the edges
+        attribute. All methods in this class return new StageOutputList instances (even
+        when the length is 1).
+
+    Parameters
+    ----------
+    edges
+        list of StageOutput to create this list from.
+    """
+
+    def __init__(self, edges: list[StageOutput | None] | None = None):
+        edges = edges or []
+        for edge in edges:
+            if not isinstance(edge, StageOutput) and edge is not None:
+                raise TypeError(
+                    f"Expected iterable of StageOutput or None, however it contained a {type(edge)}"
+                )
+        self.edges = edges
+
+    def __iter__(self):
+        """Iterate through the edges, yielding a new StageOutputList for each edge."""
+        for e in self.edges:
+            yield StageOutputList([e])
+
+    def __len__(self):
+        """Get the number of edges in this list."""
+        return len(self.edges)
+
+    def __radd__(self, other) -> "StageOutputList | NotImplementedType":
+        """Other + self."""
+        if isinstance(other, list):
+            other = StageOutputList(other)
+        if other is None:
+            other = StageOutputList([None])
+        if not isinstance(other, StageOutputList):
+            return NotImplemented
+        return StageOutputList(other.edges + self.edges)
+
+    def __add__(self, other) -> "StageOutputList | NotImplementedType":
+        """Create a new StageOutputList which concatenates the input lists."""
+        if isinstance(other, list):
+            other = StageOutputList(other)
+        if other is None:
+            other = StageOutputList([None])
+        if not isinstance(other, StageOutputList):
+            return NotImplemented
+        return StageOutputList(self.edges + other.edges)
+
+    def __or__(self, other) -> "StageOutputList":
+        """Support for '|', does the same as __add__."""
+        return self + other
+
+    def __ror__(self, other) -> "StageOutputList":
+        """Support for '|', does the same as __radd__."""
+        return other + self
+
+    def __getitem__(self, key) -> "StageOutputList":
+        """Create new StageOutputList containing requested indices from this one."""
+        if isinstance(key, slice):
+            return StageOutputList(self.edges[key])
+        elif isinstance(key, int):
+            return StageOutputList([self.edges[key]])
+        else:
+            return StageOutputList([self.edges[i] for i in key])
+
+    def __eq__(self, other):
+        """Check if this list contains the same edges as another."""
+        return all(a is b for a, b in zip(self.edges, other.edges))
 
 
 class PropertyControlField:
@@ -175,19 +284,22 @@ class Stage(Node):
 
     def __init__(
         self,
-        inputs: Iterable[StageOutput],
+        inputs: StageOutputList,
         config: Optional[Path | str] = None,
         name: Optional[str] = None,
         label: Optional[str] = None,
     ):
         super().__init__()
-        self.i = [i for i in inputs]
-        for i, input in enumerate(self.i):
+        self.i = inputs[:]
+        for i, input in enumerate(self.i.edges):
+            if input is None:
+                raise TypeError("All stage inputs must not be None")
             input.set_dest(self)
             input.dest_index = i
         if self.i:
-            self.fs = self.i[0].fs
-            self.frame_size = self.i[0].frame_size
+            assert self.i.edges[0] is not None, "not possible as checked above"
+            self.fs = self.i.edges[0].fs
+            self.frame_size = self.i.edges[0].frame_size
         else:
             self.fs = None
             self.frame_size = None
@@ -219,7 +331,7 @@ class Stage(Node):
         self.stage_memory_parameters: tuple | None = None
 
     @property
-    def o(self) -> list[StageOutput]:
+    def o(self) -> StageOutputList:
         """
         This stage's outputs. Use this object to connect this stage to the next stage in the pipeline.
         Subclass must call self.create_outputs() for this to exist.
@@ -238,12 +350,13 @@ class Stage(Node):
             number of outputs to create.
         """
         self.n_out = n_out
-        self._o = []
+        o = []
         for i in range(n_out):
             output = StageOutput(fs=self.fs, frame_size=self.frame_size)
             output.source_index = i
             output.set_source(self)
-            self._o.append(output)
+            o.append(output)
+        self._o = StageOutputList(o)
 
     def __setitem__(self, key, value):
         """Support for dictionary like access to config fields."""

--- a/python/audio_dsp/design/thread.py
+++ b/python/audio_dsp/design/thread.py
@@ -3,7 +3,7 @@
 """Contains classes for adding a thread to the DSP pipeline."""
 
 from .composite_stage import CompositeStage
-from .stage import Stage, find_config
+from .stage import Stage, StageOutputList, find_config
 
 
 class DSPThreadStage(Stage):
@@ -63,4 +63,4 @@ class Thread(CompositeStage):
 
     def add_thread_stage(self):
         """Add to this thread the stage which manages thread level commands."""
-        self.thread_stage = self.stage(DSPThreadStage, [], label=f"thread{self.id}")
+        self.thread_stage = self.stage(DSPThreadStage, StageOutputList(), label=f"thread{self.id}")

--- a/python/audio_dsp/stages/envelope_detector.py
+++ b/python/audio_dsp/stages/envelope_detector.py
@@ -38,9 +38,7 @@ class EnvelopeDetectorPeak(Stage):
             delay=delay,
             Q_sig=Q_sig,
         )
-        self.dsp_block = drc.envelope_detector_peak(
-            self.fs, self.n_in, attack_t, release_t, delay, Q_sig
-        )
+        self.dsp_block = drc.envelope_detector_peak(self.fs, self.n_in, attack_t, release_t, Q_sig)
         return self
 
 
@@ -75,7 +73,5 @@ class EnvelopeDetectorRMS(Stage):
             delay=delay,
             Q_sig=Q_sig,
         )
-        self.dsp_block = drc.envelope_detector_rms(
-            self.fs, self.n_in, attack_t, release_t, delay, Q_sig
-        )
+        self.dsp_block = drc.envelope_detector_rms(self.fs, self.n_in, attack_t, release_t, Q_sig)
         return self

--- a/python/audio_dsp/stages/signal_chain.py
+++ b/python/audio_dsp/stages/signal_chain.py
@@ -49,7 +49,7 @@ class Fork(Stage):
         fork_indices = [list(range(i, self.n_in * count, count)) for i in range(count)]
         self.forks = []
         for indices in fork_indices:
-            self.forks.append([self.o[i] for i in indices])
+            self.forks.append(self.o[(i for i in indices)])
 
     def get_frequency_response(self, nfft=512):
         """Fork has no sensible frequency response, not implemented."""

--- a/test/pipeline/test_fork.py
+++ b/test/pipeline/test_fork.py
@@ -79,7 +79,7 @@ def test_fork_copies():
     p = Pipeline(channels, frame_size=2)
     with p.add_thread() as t:
         fork = t.stage(Fork, p.i, count = 2)
-    p.set_outputs([fork.forks[0][0], fork.forks[1][0]])
+    p.set_outputs(fork.forks[0][0] + fork.forks[1][0])
 
     # input channel 0 comes out both outputs
     do_test(p, (0, 0), (0, 1))

--- a/test/pipeline/test_stage_output_list.py
+++ b/test/pipeline/test_stage_output_list.py
@@ -1,0 +1,52 @@
+"""Test that StageOutputList manipulation methods work correctly."""
+
+from audio_dsp.design.stage import StageOutputList, StageOutput
+from random import randint
+
+def list_of_edges():
+    return [StageOutput() for _ in range(randint(5, 10))]
+
+
+def test_stage_output_list_basic():
+    """Tests StageOutputList creation."""
+    input = list_of_edges()
+    sol = StageOutputList(input)
+    for i, o in zip(input, sol.edges):
+        assert i is o
+
+def test_eq():
+    """Check that StageOutputList are equal when all contained edges are the same."""
+    a = list_of_edges()
+    b = list_of_edges()
+    assert StageOutputList(a) == StageOutputList(a), "Same edges should be equal"
+    assert StageOutputList(a) == StageOutputList(a[:]), "Same edges but different list should be equal"
+    assert StageOutputList(a) != StageOutputList(b), "Different edges should be equal"
+
+def test_add():
+    """Check that StageOutputList can be combined easily."""
+    a = StageOutputList(list_of_edges())
+    b = StageOutputList(list_of_edges())
+
+    actual_add = None + a + [None] + b + None
+    actual_or = None | a | [None] | b | None
+
+    expected = [None] + a.edges + [None] + b.edges + [None]
+
+    for exp, act_add, act_or in zip(expected, actual_add.edges, actual_or.edges):
+        assert exp is act_add
+        assert exp is act_or
+
+def test_get():
+    """Check that StageOutputList can be indexed by int, tuple, slice, iterator"""
+    edges = list_of_edges()
+    a = StageOutputList(edges)
+
+    assert a[0] == StageOutputList([edges[0]])
+    assert a[0, 2, 4] == StageOutputList([edges[0], edges[2], edges[4]])
+    assert a[0:3:2] == StageOutputList([edges[0], edges[2]])
+    assert a[range(2)] == StageOutputList([edges[0], edges[1]])
+
+
+
+
+


### PR DESCRIPTION
Replaces list[StageOutput] with StageOutputList. The API for StageOutputList is designed to make manipulation during pipeline design as concise and clear as possible. The contained list[StageOutput] is used internally to the pipelne design library as before but the user does not need to know this.

Part of LCD-161

Example of simplified FRJ pipeline here: https://github.com/ed-xmos/sc_io_framework/compare/feature/track-lad?expand=1