### PR TITLE
Use xmake always.

### DIFF
--- a/python/audio_dsp/design/build_utils.py
+++ b/python/audio_dsp/design/build_utils.py
@@ -188,8 +188,8 @@ class XCommonCMakeHelper:
                     text=True,
                 )
             else:
-                # need to configure, default to Ninja because it's better
-                generator = "Ninja" if shutil.which("ninja") else "Unix Makefiles"
+                # Use Makefiles as its the only one xcommon cmake officially supports
+                generator = "Unix Makefiles"
                 ret = subprocess.Popen(
                     [
                         *(f"cmake -S {self.source_dir} -B {self.build_dir} -G".split()),


### PR DESCRIPTION
Note that if the user has already configured with ninja then this won't overwrite that. I found when testing that if the path has () in it then this will fail when using xcommon cmake and ninja, but not with Makefiles. Windows puts brackets in directory names when you download something with a duplicate name, e.g. sandbox(1). This will save time helping users but power users can still use ninja