### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/05_api_reference/integration/index.rst
+++ b/doc/05_api_reference/integration/index.rst
@@ -1,10 +1,10 @@
 .. _dsp_integration_control:
 
-Intergration and Control
+Integration and Control
 ========================
 
 This section covers the API necessary to integrate the generated DSP pipeline into your application, both data and control-wise.
-It will inroduce the API necessary for converting from high-level DSP parameters, to the ones that can be sent to the DSP pipeline.
+It will introduce the API necessary for converting from high-level DSP parameters, to the ones that can be sent to the DSP pipeline.
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
Fix typos in `doc/05_api_reference/integration/index.rst`.

* Correct the typo in the word "Intergration" to "Integration".
* Correct the typo in the word "inroduce" to "introduce".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/xmos/lib_audio_dsp/pull/243?shareId=f87b7460-513c-4c45-a6cd-7f764d138e2d).