### PR TITLE
Doc updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
   } // parameters
 
   environment {
-    XMOSDOC_VERSION = "main"
+    XMOSDOC_VERSION = "v6.3.1"
     HAS_GENERIC_CHANGES = false
   } // environment
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
   } // parameters
 
   environment {
-    XMOSDOC_VERSION = "v6.3.1"
+    XMOSDOC_VERSION = "main"
     HAS_GENERIC_CHANGES = false
   } // environment
 

--- a/doc/01_tool_user_guide/index.rst
+++ b/doc/01_tool_user_guide/index.rst
@@ -11,6 +11,12 @@ This section introduces the `audio_dsp` Python library, and how to use it to gen
 
 The following sections provide guidance on preparing the environment for the library, building a pipeline, and exploring the API documentation.
 
+.. note::
+
+    For a quick start, the Application Notes related to lib_audio_dsp on the
+    `XMOS website <https://www.xmos.com/file/lib_audio_dsp#related-application-notes>`_ come
+    preconfigured with a complete application and sandbox.
+
 .. toctree::
     :maxdepth: 2
 

--- a/doc/01_tool_user_guide/index.rst
+++ b/doc/01_tool_user_guide/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _tool_user_guide_section:
 
 Tool User Guide

--- a/doc/01_tool_user_guide/setup.rst
+++ b/doc/01_tool_user_guide/setup.rst
@@ -230,7 +230,11 @@ required:
          source .venv/bin/activate
          echo $VIRTUAL_ENV
 
-#. Open the notebook by running ``jupyter notebook
-   lib_audio_dsp/examples/app_simple_audio_dsp_integration/dsp_design.ipynb``
+#. Open the notebook by running
+
+   .. code-block:: console
+
+      jupyter notebook lib_audio_dsp/examples/app_simple_audio_dsp_integration/dsp_design.ipynb
+
    from ``lib_audio_dsp_sandbox``, as described in the 
    :ref:`Setup Steps<all_steps>` section.

--- a/doc/01_tool_user_guide/setup.rst
+++ b/doc/01_tool_user_guide/setup.rst
@@ -26,7 +26,6 @@ Software Requirements
   installed and the ``dot`` executable must be on the system path.
 - `XTC 15.3.0 <https://www.xmos.com/software-tools/>`_
 - `Python 3.10 <https://www.python.org/downloads/>`_
-- `Jupyter 7.2.1 <https://jupyter.org/install>`_
 - `CMake 3.21 <https://cmake.org/download/>`_
 
 Additionally, on Windows the following is required: 
@@ -73,11 +72,21 @@ Setup Steps
 
       mkdir lib_audio_dsp_sandbox
 
-#. Clone the library inside *lib_audio_dsp_sandbox*:
+#. Clone the library inside *lib_audio_dsp_sandbox* using SSH (if you
+   have shared your keys with Github) or HTTPS:
 
    .. code-block:: console
 
+      cd lib_audio_dsp_sandbox
+
+      # with SSH
       git clone git@github.com:xmos/lib_audio_dsp.git
+
+      # without SSH
+      git clone https://github.com/xmos/lib_audio_dsp.git
+
+   For troubleshooting SSH issues, please see this
+   `Github guide <https://docs.github.com/en/authentication/troubleshooting-ssh>`_.
 
 #. Get the sandbox inside *lib_audio_dsp_sandbox*. This step can take several
    minutes.
@@ -102,7 +111,8 @@ Setup Steps
          cmake -B build 
          cd ../../..
 
-#. Create a requirements file inside *lib_audio_dsp_sandbox*.
+#. Create a Python virtualenv inside *lib_audio_dsp_sandbox*, and install
+   lib_audio_dsp and it's requirements.
 
    .. tab:: Windows
 
@@ -110,31 +120,9 @@ Setup Steps
 
       .. code-block:: console
 
-         echo -e lib_audio_dsp/python > requirements.txt
-         echo notebook >> requirements.txt
-
-   .. tab:: Linux and macOS
-
-      On Linux and macOS:
-
-      .. code-block:: console
-
-         echo "-e lib_audio_dsp/python" > requirements.txt
-         echo notebook >> requirements.txt
-         chmod 644 requirements.txt
-
-#. Create a Python virtualenv inside *lib_audio_dsp_sandbox*.
-
-   .. tab:: Windows
-
-      On Windows:
-
-      .. code-block:: console
-
-         python -m venv .venv 
+         py -3.10 -m venv .venv 
          call .venv/Scripts/activate.bat 
-         pip install -Ur requirements.txt 
-         cd ..
+         pip install -e ./lib_audio_dsp/python
 
    .. tab:: Linux and macOS
 
@@ -142,12 +130,18 @@ Setup Steps
 
       .. code-block:: console
 
-         python -m venv .venv 
+         python3.10 -m venv .venv 
          source .venv/bin/activate 
-         pip install -Ur requirements.txt 
-         cd ..
+         pip install -e ./lib_audio_dsp/python
 
 #. Connect an XCORE-AI-EXPLORER using both USB ports
+
+#. The examples are presented as a Jupyter notebook for interactive development.
+   Install Juptyer notebooks into the Python virtual environment with the command:
+
+   .. code-block:: console
+
+      pip install notebook==7.2.1
 
 #. Open the notebook by running from *lib_audio_dsp_sandbox* the following
    command:

--- a/doc/01_tool_user_guide/setup.rst
+++ b/doc/01_tool_user_guide/setup.rst
@@ -154,7 +154,7 @@ Setup Steps
    http://127.0.0.1/ from the terminal into the browser. The top level Jupyter
    notebook page should open, as can be seein in :numref:`top_level_notebook`.
 
-   .. _top_level_notebook
+   .. _top_level_notebook:
 
    .. figure:: ../images/jupyter_notebook_top_level.png
       :width: 25%

--- a/doc/01_tool_user_guide/setup.rst
+++ b/doc/01_tool_user_guide/setup.rst
@@ -208,9 +208,25 @@ required:
    * Enable the XTC tools: the installation can be tested by running the command
      ``xrun --version`` from the terminal. If the command is not found, the XTC
      tools are not installed correctly.
-   * Enable the Python Virtual Environment: this is checked by running the
-     command ``echo %VIRTUAL_ENV%`` on Windows, or ``echo $VIRTUAL_ENV`` on
-     Linux or macOS.  The path should have been set.
+   * From your sandbox, enable the Python Virtual Environment and check the path is set:
+   
+   .. tab:: Windows
+
+      On Windows:
+
+      .. code-block:: console
+
+         call .venv/Scripts/activate.bat 
+         echo %VIRTUAL_ENV%
+
+   .. tab:: Linux and macOS
+
+      On Linux and macOS:
+
+      .. code-block:: console
+
+         source .venv/bin/activate
+         echo $VIRTUAL_ENV
 
 #. Open the notebook by running ``jupyter notebook
    lib_audio_dsp/examples/app_simple_audio_dsp_integration/dsp_design.ipynb``

--- a/doc/01_tool_user_guide/setup.rst
+++ b/doc/01_tool_user_guide/setup.rst
@@ -151,8 +151,10 @@ Setup Steps
       jupyter notebook lib_audio_dsp/examples/app_simple_audio_dsp_integration/dsp_design.ipynb
 
    If a blank screen appears or nothing opens, then copy the link starting with
-   http://127.0.0.1/ from the terminal into the browser. The following page
-   should open:
+   http://127.0.0.1/ from the terminal into the browser. The top level Jupyter
+   notebook page should open, as can be seein in :numref:`top_level_notebook`.
+
+   .. _top_level_notebook
 
    .. figure:: ../images/jupyter_notebook_top_level.png
       :width: 25%

--- a/doc/01_tool_user_guide/using_the_tool.rst
+++ b/doc/01_tool_user_guide/using_the_tool.rst
@@ -24,7 +24,9 @@ with output limiter. In this design the product will stream real time audio
 boosting or suppressing the treble and bass and then limiting the output
 amplitude to protect the output device.
 
-The DSP pipeline will perform the following processes:
+The DSP pipeline will perform the processes shown in :numref:`bass_treble_pipeline`.
+
+.. _bass_treble_pipeline:
 
 .. figure:: ../images/bass_treble_limit.drawio.png
    :width: 100%

--- a/doc/02_design_guide/index.rst
+++ b/doc/02_design_guide/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _design_guide_section:
 
 Design Guide

--- a/doc/03_dsp_components/index.rst
+++ b/doc/03_dsp_components/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _dsp_components_section:
 
 DSP Components

--- a/doc/04_run_time_control_guide/control_interface_walkthrough.rst
+++ b/doc/04_run_time_control_guide/control_interface_walkthrough.rst
@@ -23,32 +23,32 @@ This code snippet will generate the pipeline diagram shown in :numref:`run_time_
 In this example the tuning methods on the stages in the pipeline are not called which means
 the code that is generated will intialise the stages with their default configuration values.
 
-A point of interest in this example is that the `label` argument to the pipeline `stage`
+A point of interest in this example is that the ``label`` argument to the pipeline ``stage``
 method is set, but only for the volume control stage. The label for the volume control in 
-this example is `volume`. After generating the source code for this pipeline, a file will
-be created in the specified directory named `adsp_instance_id_auto.h` (assuming that the pipeline
+this example is ``volume``. After generating the source code for this pipeline, a file will
+be created in the specified directory named ``adsp_instance_id_auto.h`` (assuming that the pipeline
 identifier has been left as its default value of "auto"). The contents of the generated file are shown below:
 
 .. literalinclude:: ../../test/pipeline/doc_examples/run_time_dsp/src/dsp/adsp_instance_id_auto.h
    :language: C
 
-In this file the macro `volume_stage_index` is defined. The value of this macro can be used by
+In this file the macro ``volume_stage_index`` is defined. The value of this macro can be used by
 the control interface to find the volume control stage and process control commands. The benefit
 of this to an application author is that this header file can be included in the application and
-the value of `volume_stage_index` will always be correct, even when the pipeline is redesigned.
+the value of ``volume_stage_index`` will always be correct, even when the pipeline is redesigned.
 
 Writing the Configuration of a Stage
 ====================================
 
 Each stage type has a set of controllable parameters that can be read or written. A description of
 each parameter along with its type and name can be found in the :ref:`dsp_stages_section` section
-in the DSP components document. For volume control, there is a command named `CMD_VOLUME_CONTROL_TARGET_GAIN`
+in the DSP components document. For volume control, there is a command named ``CMD_VOLUME_CONTROL_TARGET_GAIN``
 that can be updated at run time to set the volume. This command is defined in the generated header file
-`cmds.h` which will be placed into the build directory at `src.autogen/common/cmds.h`. `cmds.h` contains all
+``cmds.h`` which will be placed into the build directory at ``src.autogen/common/cmds.h``. ``cmds.h`` contains all
 the command IDs for all the stage types that CMake found.
 
 It is also possible to see the available control parameters, along with the values they will be set to, while
-designing the pipeline in Python. This can be done using the `get_config` method of the stage as shown below.
+designing the pipeline in Python. This can be done using the ``get_config`` method of the stage as shown below.
 
 .. literalinclude:: ../../test/pipeline/doc_examples/run_time_control.py
    :language: python
@@ -59,35 +59,35 @@ This will print this dictionary of parameters:
 
 .. literalinclude:: ../../test/pipeline/doc_examples/run_time_dsp/config.txt
 
-This dictionary does not contain `CMD_VOLUME_CONTROL_TARGET_GAIN`, but is does contain "target_gain". The final
-command name is constructed as "CMD_{STAGE_TYPE}_{PARAMETER}" where stage type and parameter should be replaced with
-the correct values for each, capitalised. All stages of the same type (e.g. `VolumeControl`) will have the same
+This dictionary does not contain ``CMD_VOLUME_CONTROL_TARGET_GAIN``, but is does contain "target_gain". The final
+command name is constructed as ``CMD_{STAGE_TYPE}_{PARAMETER}`` where stage type and parameter should be replaced with
+the correct values for each, capitalised. All stages of the same type (e.g. ``VolumeControl``) will have the same
 set of parameters. 
 
 The format and type of the control parameters for each stage are chosen to optimise processing time on the
-DSP thread. For example, `CMD_VOLUME_CONTROL_TARGET_GAIN` is not a floating point value in decibels, but rather
+DSP thread. For example, ``CMD_VOLUME_CONTROL_TARGET_GAIN`` is not a floating point value in decibels, but rather
 a linear fixed point value. For this example we can use the convenience function
-`adsp_dB_to_gain()` which is defined in `control/signal_chain.h`.
+``adsp_dB_to_gain()`` which is defined in ``control/signal_chain.h``.
 
-In order to send a control command, the API defined in `stages/adsp_control.h` is used. This API is documented in the
+In order to send a control command, the API defined in ``stages/adsp_control.h`` is used. This API is documented in the
 :ref:`api_reference_section`, in the :ref:`dsp_control` section. Complete the
 following steps:
 
 #. Create a thread that will be updating the DSP configuration. This thread must be on the same tile as the DSP.
 
-#. Create a new `adsp_controller_t` from the `adsp_pipeline_t` that was initialised for the generated pipeline. If
-   multiple threads will be attempting control, each thread must have a unique instance of `adsp_controller_t` to ensure
+#. Create a new ``adsp_controller_t`` from the ``adsp_pipeline_t`` that was initialised for the generated pipeline. If
+   multiple threads will be attempting control, each thread must have a unique instance of ``adsp_controller_t`` to ensure
    thread safety.
 
-#. Initialise a new `adsp_stage_control_cmd_t`, specifying the instance ID (`volume_stage_index`), the command
-   ID (`CMD_VOLUME_CONTROL_TARGET_GAIN`), and payload length (`sizeof(int32_t)`).
+#. Initialise a new ``adsp_stage_control_cmd_t``, specifying the instance ID (``volume_stage_index``), the command
+   ID (``CMD_VOLUME_CONTROL_TARGET_GAIN``), and payload length (``sizeof(int32_t)``).
 
-#. Create the command payload; this will be an `int32_t` containing the computed gain. Update the command payload
+#. Create the command payload; this will be an ``int32_t`` containing the computed gain. Update the command payload
    pointer to reference the payload.
 
-#. Call `adsp_write_module_config` until it returns `ADSP_CONTROL_SUCCESS`. There may be in-progress write or read 
+#. Call ``adsp_write_module_config`` until it returns ``ADSP_CONTROL_SUCCESS``. There may be in-progress write or read 
    commands which have been issued but not completed when starting the new command. In this scenario
-   the `adsp_write_module_config` will return `ADSP_CONTROL_BUSY` which means that the attempt to write had no 
+   the ``adsp_write_module_config`` will return ``ADSP_CONTROL_BUSY`` which means that the attempt to write had no 
    effect and should be attempted again.
 
 A full example of a control thread that does this is shown below.
@@ -102,11 +102,11 @@ Reading the Configuration of a Stage
 
 In some cases it makes sense to read back the configuration of the stage. Some stages have dynamic values that are 
 updated as the audio is processed and can be read back to the control thread. Volume control is an example of this
-as it will smoothly adjust the gain towards `CMD_VOLUME_CONTROL_TARGET_GAIN`; the current value of the gain which
-is actually being applied can be read by reading from the parameter `CMD_VOLUME_CONTROL_GAIN`. The API for reading
+as it will smoothly adjust the gain towards ``CMD_VOLUME_CONTROL_TARGET_GAIN``; the current value of the gain which
+is actually being applied can be read by reading from the parameter ``CMD_VOLUME_CONTROL_GAIN``. The API for reading
 is largely the same as writing, except the control API will write to the payload buffer.
 
-This code example shows how to read the current `CMD_VOLUME_CONTROL_GAIN` parameter from the "volume" stage that
+This code example shows how to read the current ``CMD_VOLUME_CONTROL_GAIN`` parameter from the "volume" stage that
 is created in the example above.
 
 .. literalinclude:: ../../test/pipeline/doc_examples/run_time_dsp/src/main.c
@@ -135,6 +135,6 @@ For a read command the process is similar. The control thread requests a read by
 The stage will see this and update the configuration struct with the latest value and notify the control thread, via the
 control state variable, that it has completed the request.
 
-The control API ensures thread safety through the use of the `adsp_controller_t` struct. As long as each thread uses
-a unique instance of `adsp_controller_t` then the control APIs will return `ADSP_CONTROL_BUSY` if a command that was
-initialised by another `adsp_controller_t` is ongoing.
+The control API ensures thread safety through the use of the ``adsp_controller_t`` struct. As long as each thread uses
+a unique instance of ``adsp_controller_t`` then the control APIs will return ``ADSP_CONTROL_BUSY`` if a command that was
+initialised by another ``adsp_controller_t`` is ongoing.

--- a/doc/04_run_time_control_guide/index.rst
+++ b/doc/04_run_time_control_guide/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _run_time_control_guide_section:
 
 Run-Time Control User Guide

--- a/doc/05_api_reference/index.rst
+++ b/doc/05_api_reference/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _api_reference_section:
 
 API Reference

--- a/doc/05_api_reference/integration/helpers.rst
+++ b/doc/05_api_reference/integration/helpers.rst
@@ -28,13 +28,21 @@ DRC helpers
 
 .. doxygenfunction:: peak_expander_slope_from_ratio
 
+.. doxygenfunction:: qxx_to_db
+
+.. doxygenfunction:: qxx_to_db_pow
+
 Reverb helpers
 ==============
 
 .. doxygenfile:: control/reverb.h
+
+.. doxygenfile:: control/reverb_plate.h
 
 
 Signal chain helpers
 ====================
 
 .. doxygenfunction:: time_to_samples
+
+.. doxygenfunction:: adsp_dB_to_gain

--- a/doc/05_api_reference/integration/helpers.rst
+++ b/doc/05_api_reference/integration/helpers.rst
@@ -32,6 +32,9 @@ DRC helpers
 
 .. doxygenfunction:: qxx_to_db_pow
 
+.. doxygenfile:: control/drc.h
+
+
 Reverb helpers
 ==============
 
@@ -43,6 +46,5 @@ Reverb helpers
 Signal chain helpers
 ====================
 
-.. doxygenfunction:: time_to_samples
+.. doxygenfile:: control/signal_chain.h
 
-.. doxygenfunction:: adsp_dB_to_gain

--- a/doc/05_api_reference/modules/drc.rst
+++ b/doc/05_api_reference/modules/drc.rst
@@ -344,7 +344,7 @@ This can be used to reduce the level of the *input* signal when the
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.sidechain.compressor_rms_sidechain_mono
+    .. autoclass:: audio_dsp.dsp.drc.compressor_rms_sidechain_mono
         :noindex:
 
         .. automethod:: process
@@ -449,7 +449,7 @@ initialisation to simplify run-time computation.
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.expander.noise_suppressor_expander
+    .. autoclass:: audio_dsp.dsp.drc.noise_suppressor_expander
         :noindex:
 
         .. automethod:: process

--- a/doc/05_api_reference/modules/drc.rst
+++ b/doc/05_api_reference/modules/drc.rst
@@ -58,7 +58,7 @@ A peak-based envelope detector will run its EMA using the absolute value of the 
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.envelope_detector_peak
+    .. autoclass:: audio_dsp.dsp.drc.envelope_detector_peak
         :noindex:
 
         .. automethod:: process
@@ -90,7 +90,7 @@ input sample. It returns the mean² in order to avoid a square root.
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.envelope_detector_rms
+    .. autoclass:: audio_dsp.dsp.drc.envelope_detector_rms
         :noindex:
 
         .. automethod:: process
@@ -124,7 +124,7 @@ instantaneously, so has no attack or release times.
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.clipper
+    .. autoclass:: audio_dsp.dsp.drc.clipper
         :noindex:
 
         .. automethod:: process
@@ -175,7 +175,7 @@ When envelope is above the threshold, the new gain is calculated as
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.limiter_peak
+    .. autoclass:: audio_dsp.dsp.drc.limiter_peak
         :noindex:
 
         .. automethod:: process
@@ -209,7 +209,7 @@ headroom bits.
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.hard_limiter_peak
+    .. autoclass:: audio_dsp.dsp.drc.hard_limiter_peak
         :noindex:
 
         .. automethod:: process
@@ -242,7 +242,7 @@ When envelope is above the threshold, the new gain is calculated as
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.limiter_rms
+    .. autoclass:: audio_dsp.dsp.drc.limiter_rms
         :noindex:
 
         .. automethod:: process
@@ -306,7 +306,7 @@ When the envelope is above the threshold, the new gain is calculated as
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.drc.compressor_rms
+    .. autoclass:: audio_dsp.dsp.drc.compressor_rms
         :noindex:
 
         .. automethod:: process
@@ -398,7 +398,7 @@ the input signal. Otherwise, unity gain is applied.
 
         .. rubric:: Python API
 
-    .. autoclass:: audio_dsp.dsp.drc.expander.noise_gate
+    .. autoclass:: audio_dsp.dsp.drc.noise_gate
         :noindex:
 
         .. automethod:: process

--- a/doc/05_api_reference/modules/index.rst
+++ b/doc/05_api_reference/modules/index.rst
@@ -1,3 +1,7 @@
+.. raw:: latex
+
+    \newpage
+
 .. _dsp_modules_section:
 
 DSP Modules

--- a/doc/Doxyfile.inc
+++ b/doc/Doxyfile.inc
@@ -12,6 +12,7 @@ INPUT += ../lib_audio_dsp/api/dsp \
          ../lib_audio_dsp/api/stages/adsp_pipeline.h \
          ../lib_audio_dsp/api/control/helpers.h \
          ../lib_audio_dsp/api/control/reverb.h \
+         ../lib_audio_dsp/api/control/reverb_plate.h \
          ../lib_audio_dsp/api/control/biquad.h \
          ../lib_audio_dsp/api/control/signal_chain.h \
 

--- a/doc/Doxyfile.inc
+++ b/doc/Doxyfile.inc
@@ -16,7 +16,6 @@ INPUT += ../lib_audio_dsp/api/dsp \
          ../lib_audio_dsp/api/control/biquad.h \
          ../lib_audio_dsp/api/control/signal_chain.h \
          ../lib_audio_dsp/api/control/drc.h \
-         ../lib_audio_dsp/api/control/signal_chain.h \
 
 INCLUDE_PATH = ../lib_audio_dsp/api \
 

--- a/doc/Doxyfile.inc
+++ b/doc/Doxyfile.inc
@@ -15,6 +15,8 @@ INPUT += ../lib_audio_dsp/api/dsp \
          ../lib_audio_dsp/api/control/reverb_plate.h \
          ../lib_audio_dsp/api/control/biquad.h \
          ../lib_audio_dsp/api/control/signal_chain.h \
+         ../lib_audio_dsp/api/control/drc.h \
+         ../lib_audio_dsp/api/control/signal_chain.h \
 
 INCLUDE_PATH = ../lib_audio_dsp/api \
 

--- a/doc/lib_audio_dsp.rst
+++ b/doc/lib_audio_dsp.rst
@@ -1,6 +1,10 @@
-
 Lib Audio DSP
 #############
+
+.. raw:: latex
+
+    \newpage
+
 
 .. rubric:: Introduction
 
@@ -42,6 +46,8 @@ This document covers the following topics:
 The subsequent sections provide comprehensive insights into the functionalities and applications of lib_audio_dsp,
 detailing how to leverage its features for efficient audio signal processing.
 
+For example appliations, see the Application Notes related to lib_audio_dsp on the
+`XMOS website <https://www.xmos.com/file/lib_audio_dsp#related-application-notes>`_.
 
 .. toctree::
     :maxdepth: 2

--- a/lib_audio_dsp/api/control/reverb_plate.h
+++ b/lib_audio_dsp/api/control/reverb_plate.h
@@ -39,6 +39,7 @@ static inline int32_t adsp_reverb_plate_calc_damping(float damping) {
  * for passing to a reverb.
  *
  * @param bandwidth The chose value of bandwidth.
+ * @param fs The sampling frequency in Hz
  * @return Bandwidth as a Q_RVP fixed point integer, clipped to the accepted range.
  */
 static inline int32_t adsp_reverb_plate_calc_bandwidth(float bandwidth, float fs) {

--- a/python/audio_dsp/design/build_utils.py
+++ b/python/audio_dsp/design/build_utils.py
@@ -1,9 +1,6 @@
 # Copyright 2024-2025 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
-"""
-Utility functions for building and running the application within
-the Jupyter notebook.
-"""
+"""Utility functions for building and running the application within the Jupyter notebook."""
 
 import IPython
 import ipywidgets as widgets
@@ -180,8 +177,8 @@ class XCommonCMakeHelper:
         """
         Invoke CMake with the options specified in this class instance.
         Invokation will be of the form
-        "cmake -S <source_dir> -B <build_dir>". On first run, the invokation
-        will also contain "-G <generator>", where "generator"
+        ``cmake -S <source_dir> -B <build_dir>``. On first run, the invokation
+        will also contain ``-G <generator>``, where "generator"
         will be either "Ninja" if Ninja is present on the current system or
         "Unix Makefiles" if it is not.
 
@@ -236,7 +233,7 @@ class XCommonCMakeHelper:
         """
         Invoke CMake's build with the options specified in this class instance.
         Invokation will be of the form
-        "cmake --build <build_dir> --target <target_name>", where the target
+        ``cmake --build <build_dir> --target <target_name>``, where the target
         name is constructed as per this class' docstring.
 
         Returns
@@ -256,14 +253,18 @@ class XCommonCMakeHelper:
     def run(self, xscope: bool = True, hostname: str = "localhost", port: str = "12345") -> int:
         """
         Invoke xrun or xgdb with the options specified in this class instance.
-        If xscope is True, the invokation will be of the form
-        'xgdb -q --return-child-result --batch
+        If xscope is True, the invocation will be of the form::
+
+            xgdb -q --return-child-result --batch
             -ex "connect --xscope-port <hostname>:<port> --xscope"
             -ex "load"
             -ex "continue"
-            <binary>',
-        whereas if xscope if False the invokation will be of the form
-        "xrun <binary>",
+            <binary>
+
+        whereas if xscope if False the invocation will be of the form::
+
+            xrun <binary>
+
         where the path to the binary is constructed as per this
         class' docstring.
 
@@ -282,6 +283,7 @@ class XCommonCMakeHelper:
         -------
         returncode
             Return code from the invokation of xrun or xgdb. 0 if success.
+
         """
         app = (
             f"{self.bin_dir / self.config_name / (self.project_name + self.config_suffix + '.xe')}"

--- a/python/audio_dsp/design/build_utils.py
+++ b/python/audio_dsp/design/build_utils.py
@@ -253,7 +253,8 @@ class XCommonCMakeHelper:
     def run(self, xscope: bool = True, hostname: str = "localhost", port: str = "12345") -> int:
         """
         Invoke xrun or xgdb with the options specified in this class instance.
-        If xscope is True, the invocation will be of the form::
+
+        If xscope is True the invocation will be of the form::
 
             xgdb -q --return-child-result --batch
             -ex "connect --xscope-port <hostname>:<port> --xscope"
@@ -283,7 +284,6 @@ class XCommonCMakeHelper:
         -------
         returncode
             Return code from the invokation of xrun or xgdb. 0 if success.
-
         """
         app = (
             f"{self.bin_dir / self.config_name / (self.project_name + self.config_suffix + '.xe')}"

--- a/python/audio_dsp/design/templates/py_stage_doc.mako
+++ b/python/audio_dsp/design/templates/py_stage_doc.mako
@@ -13,7 +13,7 @@ ${"="*len(cl)}
 ${cl}
 ${"="*len(cl)}
 
-.. autoclass:: ${module}.${cl}
+.. autoclass:: audio_dsp.stages.${cl}
     :noindex:
     :members:
     :inherited-members: Stage

--- a/python/audio_dsp/design/templates/py_stage_doc.mako
+++ b/python/audio_dsp/design/templates/py_stage_doc.mako
@@ -58,8 +58,10 @@ details on reading and writing these commands, see the Run-Time Control User Gui
 %>
 ##  do the printing, use ljust to pad to max size
 .. table::
-  :widths: ${help_width}, ${pay_width} 
+  :widths: ${help_width}, ${pay_width}
+% if len(row_list) > 6:
   :class: longtable
+%endif
 
   ${"="*max_help}  ${"="*max_pay}
   ${"Control parameter".ljust(max_help)}  ${"Payload length".ljust(max_pay)}

--- a/python/audio_dsp/dsp/drc/drc.py
+++ b/python/audio_dsp/dsp/drc/drc.py
@@ -808,48 +808,6 @@ class hard_limiter_peak(limiter_peak):
             )
 
 
-class lookahead_limiter_peak(peak_compressor_limiter_base):
-    """Not implemented. Peak limiter with built in delay for avoiding
-    clipping.
-    """
-
-    def __init__(self, fs, n_chans, threshold_db, attack_t, release_t, delay, Q_sig=dspg.Q_SIG):
-        super().__init__(fs, n_chans, threshold_db, attack_t, release_t, Q_sig)
-
-        self.delay = np.ceil(attack_t * fs)
-        self.delay_line = np.zeros(self.delay)
-        raise NotImplementedError
-
-    def process(self, sample, channel=0):
-        """Not implemented."""
-        raise NotImplementedError
-
-    def process_xcore(self, sample, channel=0, return_int=False):
-        """Not implemented."""
-        raise NotImplementedError
-
-
-class lookahead_limiter_rms(rms_compressor_limiter_base):
-    """Not implemented. RMS limiter with built in delay for avoiding
-    clipping.
-    """
-
-    def __init__(self, fs, n_chans, threshold_db, attack_t, release_t, delay, Q_sig=dspg.Q_SIG):
-        super().__init__(fs, n_chans, threshold_db, attack_t, release_t, Q_sig)
-
-        self.delay = np.ceil(attack_t * fs)
-        self.delay_line = np.zeros(self.delay)
-        raise NotImplementedError
-
-    def process(self, sample, channel=0):
-        """Not implemented."""
-        raise NotImplementedError
-
-    def process_xcore(self, sample, channel=0, return_int=False):
-        """Not implemented."""
-        raise NotImplementedError
-
-
 # TODO lookahead limiters and compressors
 # TODO add soft limiter
 # TODO add peak compressors

--- a/python/audio_dsp/dsp/drc/stereo_compressor_limiter.py
+++ b/python/audio_dsp/dsp/drc/stereo_compressor_limiter.py
@@ -261,6 +261,11 @@ class peak_compressor_limiter_stereo_base(compressor_limiter_stereo_base):
     """
     A compressor/limiter with a peak envelope detector.
 
+    Parameters
+    ----------
+    threshold_db : float
+        Threshold in decibels above which limiting occurs.
+
     Attributes
     ----------
     threshold_db : float
@@ -306,6 +311,11 @@ class rms_compressor_limiter_stereo_base(compressor_limiter_stereo_base):
 
     Note the threshold is saved in the power domain, as the RMS envelope
     detector returns x².
+
+    Parameters
+    ----------
+    threshold_db : float
+        Threshold in decibels above which limiting occurs.
 
     Attributes
     ----------
@@ -359,6 +369,11 @@ class limiter_peak_stereo(peak_compressor_limiter_stereo_base):
     time sets how fast the limiter starts limiting. The release time
     sets how long the signal takes to ramp up to it's original level
     after the envelope is below the threshold.
+
+    Parameters
+    ----------
+    threshold_dB : float
+        Threshold in decibels above which limiting occurs.
     """
 
     def __init__(self, fs, threshold_dB, attack_t, release_t, Q_sig=dspg.Q_SIG):
@@ -383,6 +398,24 @@ class compressor_rms_stereo(rms_compressor_limiter_stereo_base):
     starts compressing. The release time sets how long the signal takes
     to ramp up to it's original level after the envelope is below the
     threshold.
+
+    Parameters
+    ----------
+    threshold_dB : float
+        Threshold in decibels above which limiting occurs.
+    ratio : float
+        Compression gain ratio applied when the signal is above the
+        threshold
+
+    Attributes
+    ----------
+    ratio : float
+    slope : float
+        The slope factor of the compressor, defined as
+        `slope = (1 - 1/ratio) / 2`.
+    slope_f32 : float32
+        The slope factor of the compressor, used for int32 to float32
+        processing.
     """
 
     def __init__(self, fs, ratio, threshold_dB, attack_t, release_t, Q_sig=dspg.Q_SIG):

--- a/python/audio_dsp/dsp/fd_block_fir.py
+++ b/python/audio_dsp/dsp/fd_block_fir.py
@@ -43,7 +43,7 @@ class fir_block_fd(dspg.dsp_block):
         attempt of ``nfft = 2**(ceil(log2(frame_advance)) + 1)`` is made,
         but may need to be increased for longer overlaps. If it is set,
         it must be a power of 2.
-    gain_dB : float, optional
+    gain_db : float, optional
         A gain applied to the filters output, by default 0.0
 
     Attributes
@@ -83,7 +83,7 @@ class fir_block_fd(dspg.dsp_block):
         frame_advance: int,
         frame_overlap: int = 0,
         nfft: Optional[int] = None,
-        gain_dB: float = 0.0,
+        gain_db: float = 0.0,
         Q_sig: int = dspg.Q_SIG,
     ):
         super().__init__(fs, n_chans, Q_sig)
@@ -99,7 +99,7 @@ class fir_block_fd(dspg.dsp_block):
             frame_advance,
             frame_overlap,
             nfft,
-            gain_dB=gain_dB,
+            gain_db=gain_db,
         )
 
         self.nfft = 2 * (self.coeffs_fd.shape[1] - 1)
@@ -325,7 +325,7 @@ def generate_fd_fir(
     frame_advance: int,
     frame_overlap: int = 0,
     nfft: Optional[int] = None,
-    gain_dB: float = 0.0,
+    gain_db: float = 0.0,
     verbose=False,
 ):
     """
@@ -353,7 +353,7 @@ def generate_fd_fir(
         attempt of ``nfft = 2**(ceil(log2(frame_advance)) + 1)`` is made,
         but may need to be increased for longer overlaps. If it is set,
         it must be a power of 2.
-    gain_dB : float, optional
+    gain_db : float, optional
         A gain applied to the filters output, by default 0.0
     verbose : bool, optional
         Enable verbose printing, by default False
@@ -461,7 +461,7 @@ def generate_fd_fir(
         prepared_coefs = td_coefs
 
     # Apply the gains
-    prepared_coefs *= 10.0 ** (gain_dB / 20.0)
+    prepared_coefs *= 10.0 ** (gain_db / 20.0)
 
     assert len(prepared_coefs) % taps_per_phase == 0
 
@@ -545,7 +545,7 @@ if __name__ == "__main__":
 
     output_path = os.path.realpath(args.output)
     filter_path = os.path.realpath(args.filter)
-    gain_dB = args.gain
+    gain_db = args.gain
 
     if os.path.exists(filter_path):
         coefs = np.load(filter_path)
@@ -566,5 +566,5 @@ if __name__ == "__main__":
         args.frame_advance,
         frame_overlap=args.frame_overlap,
         nfft=args.nfft,
-        gain_dB=gain_dB,
+        gain_db=gain_db,
     )

--- a/python/audio_dsp/dsp/td_block_fir.py
+++ b/python/audio_dsp/dsp/td_block_fir.py
@@ -58,7 +58,7 @@ class fir_block_td(dspg.dsp_block):
         filter_name: str,
         output_path: Path,
         frame_advance=8,
-        gain_dB=0.0,
+        gain_db=0.0,
         Q_sig: int = dspg.Q_SIG,
     ):
         super().__init__(fs, n_chans, Q_sig)
@@ -76,7 +76,7 @@ class fir_block_td(dspg.dsp_block):
             filter_name,
             output_path,
             self.frame_advance,
-            gain_dB,
+            gain_db,
         )
 
     def reset_state(self) -> None:
@@ -184,7 +184,7 @@ def generate_td_fir(
     filter_name: str,
     output_path: Path,
     frame_advance=8,
-    gain_dB=0.0,
+    gain_db=0.0,
     verbose=False,
 ):
     """
@@ -204,7 +204,7 @@ def generate_td_fir(
     frame_advance : int, optional
         The size in samples of a frame, measured in time domain samples,
         by default 8. Only multiples of 8 are supported.
-    gain_dB : float, optional
+    gain_db : float, optional
         A gain applied to the filter's output, by default 0.0
     verbose : bool, optional
         Enable verbose printing, by default False
@@ -240,7 +240,7 @@ def generate_td_fir(
         prepared_coefs = td_coefs
 
     # Apply the gains
-    prepared_coefs = prepared_coefs * 10.0 ** (gain_dB / 20.0)
+    prepared_coefs = prepared_coefs * 10.0 ** (gain_db / 20.0)
 
     with open(output_file_name, "w") as fh:
         fh.write('#include "dsp/td_block_fir.h"\n\n')
@@ -291,7 +291,7 @@ if __name__ == "__main__":
 
     output_path = os.path.realpath(args.output)
     filter_path = os.path.realpath(args.filter)
-    gain_dB = args.gain
+    gain_db = args.gain
 
     if os.path.exists(filter_path):
         coefs = np.load(filter_path)
@@ -307,4 +307,4 @@ if __name__ == "__main__":
 
     os.makedirs(args.output, exist_ok=True)
 
-    generate_td_fir(coefs, filter_name, output_path, gain_dB=gain_dB)
+    generate_td_fir(coefs, filter_name, output_path, gain_db=gain_db)

--- a/python/audio_dsp/stages/__init__.py
+++ b/python/audio_dsp/stages/__init__.py
@@ -25,6 +25,7 @@ from .reverb import ReverbRoom, ReverbRoomStereo, ReverbPlateStereo
 from .fir import FirDirect
 from .compressor import CompressorRMS
 from .compressor_sidechain import CompressorSidechain
+from .envelope_detector import EnvelopeDetectorPeak, EnvelopeDetectorRMS
 
 # helper from design which allows listing all the available stages.
 from ..design.stage import all_stages

--- a/settings.yml
+++ b/settings.yml
@@ -32,6 +32,7 @@ documentation:
       pdf_title: '{{title}} (README)'
       pdf_filename: '{{lib_name}}_v{{version}}_readme'
       pdf_short: yes
+  latex_toc_depth: 3
 
 software:
   cognidox_part_number: XM-015102-SM

--- a/stage_config/reverb_plate_stereo.yaml
+++ b/stage_config/reverb_plate_stereo.yaml
@@ -26,15 +26,14 @@ module:
         The amount of diffusion in the late part of the reverb. To
         convert a diffusion value between 0 and 1 to an ``int32_t``
         control value, use the function `adsp_reverb_plate_calc_late_diffusion`` in
-        ``control/reverb.h``.
+        ``control/reverb_plate.h``.
     bandwidth:
       type: int32_t
       help: >
         The input low pass coefficient in Q0.31 format. A bandwidth in
         Hertz can be converted to an ``int32_t`` control value using the
-        function xxxxx.
-        Alternatively, a bandwidth between 0 and 1 can be converted
-        using the function `adsp_reverb_plate_calc_bandwidth``.
+        function `adsp_reverb_plate_calc_bandwidth`` in
+        ``control/reverb_plate.h``.
     wet_gain1:
       type: int32_t
       help: >

--- a/test/fd_block_fir/ref_fir.py
+++ b/test/fd_block_fir/ref_fir.py
@@ -86,7 +86,7 @@ def generate_debug_fir(
     frame_advance=None,
     frame_overlap=None,
     td_block_length=None,
-    gain_dB=0.0,
+    gain_db=0.0,
     verbose=False,
 ):
     """Convert the input array into a header to be included in a C debug tests."""

--- a/test/fd_block_fir/test_fd_block_fir.py
+++ b/test/fd_block_fir/test_fd_block_fir.py
@@ -20,7 +20,7 @@ from filelock import FileLock
 build_dir_name = "build"
 
 
-def build_and_run_tests(dir_name, coefficients, frame_advance = 16, td_block_length = None, frame_overlap = 0, sim = True, gain_dB = 0.0):
+def build_and_run_tests(dir_name, coefficients, frame_advance = 16, td_block_length = None, frame_overlap = 0, sim = True, gain_db = 0.0):
 
     local_build_dir_name = build_dir_name
 
@@ -40,9 +40,9 @@ def build_and_run_tests(dir_name, coefficients, frame_advance = 16, td_block_len
         # run the filter_generator on the coefs
         try:
             generate_fd_fir(coefficients, "dut", gen_dir, frame_advance, frame_overlap, td_block_length, 
-                        gain_dB = gain_dB, verbose = True)
+                        gain_db = gain_db, verbose = True)
             generate_debug_fir(coefficients, "dut", gen_dir, frame_advance, frame_overlap, td_block_length, 
-                        gain_dB = gain_dB, verbose = True)
+                        gain_db = gain_db, verbose = True)
         except ValueError as e:
             if "Bad config" not in str(e):
                 raise e

--- a/test/td_block_fir/test_td_block_fir.py
+++ b/test/td_block_fir/test_td_block_fir.py
@@ -26,7 +26,7 @@ gen_dir = Path(__file__).parent / "autogen"
 build_dir = Path(__file__).parent / build_dir_name
 
 
-def build_and_run_tests(dir_name, coefficients, frame_advance = 8, td_block_length = 8, frame_overlap = 0, sim = True, gain_dB = 0.0):
+def build_and_run_tests(dir_name, coefficients, frame_advance = 8, td_block_length = 8, frame_overlap = 0, sim = True, gain_db = 0.0):
 
     local_build_dir_name = build_dir_name
 
@@ -41,8 +41,8 @@ def build_and_run_tests(dir_name, coefficients, frame_advance = 8, td_block_leng
 
         # run the filter_generator on the coefs
         try:
-            generate_td_fir(coefficients, "dut", gen_dir, gain_dB=gain_dB)
-            generate_debug_fir(coefficients, "dut", gen_dir, gain_dB = gain_dB, verbose = False)
+            generate_td_fir(coefficients, "dut", gen_dir, gain_db=gain_db)
+            generate_debug_fir(coefficients, "dut", gen_dir, gain_db = gain_db, verbose = False)
         except ValueError as e:
             # print('Success (Expected Fail)')
             print('coef count', len(coefficients), 'frame_advance', frame_advance, 'td_block_length', td_block_length, 'frame_overlap', frame_overlap)


### PR DESCRIPTION
- [x] Getting_started/setup_steps needs breaks after images to get them in sensible places in the text
- [x] Same in Using_the_tool/creating_a_pipeline
- [x] 4.1 Defining a Controllable Pipeline image placement issue again, but better because it uses reference instead of :
- [x] Page break between big sections might be nice
- [ ] class audio_dsp.design.pipeline_executor.PipelineView  and class audio_dsp.design.stage.StageOutputList spill over page edge -> not possible with current Sphinx
- [x] API reference needs more headings
- [x] Not all module helper functions documented
- [x] Intro doesn’t work 
- [x] Setup guide doesn’t work
- [x] Link to app notes in docs + readme