### PR TITLE
Add RuntimeError if inputs do not cross correct number of threads

### DIFF
--- a/python/audio_dsp/design/stage.py
+++ b/python/audio_dsp/design/stage.py
@@ -14,6 +14,7 @@ from typing import Optional
 from types import NotImplementedType
 from copy import deepcopy
 
+
 def find_config(name):
     """
     Find the config yaml file for a stage by looking for it
@@ -342,26 +343,28 @@ class Stage(Node):
         self.stage_memory_string: str = ""
         self.stage_memory_parameters: tuple | None = None
 
-        if len(inputs.edges) >= 1:
+        if len(self.i.edges) >= 1:
             thread_crossings = []
             for edge in inputs.edges:
-                thread_crossings.append(len(set(edge.crossings)))
+                thread_crossings.append(len(set(edge.crossings)))  # pyright: ignore checked above
 
-            if not all(x==thread_crossings[0] for x in thread_crossings):
-
+            if not all(x == thread_crossings[0] for x in thread_crossings):
                 input_msg = "\n"
 
-                for i, edge in enumerate(inputs.edges):
-                    input_msg += f"Input {i} crosses threads {set(edge.crossings)}.\n"
+                for i, edge in enumerate(self.i.edges):
+                    input_msg += f"Input {i} crosses threads {set(edge.crossings)}.\n"  # pyright: ignore checked above
 
-                raise RuntimeError(f"\nAll stage inputs to {type(self).__name__} (label={self.label})"
-                " must cross the same number of threads.\n"
-                f"Currently, inputs cross {thread_crossings} threads.\nInputs with less than "
-                f"{max(thread_crossings)} thread crossings must pass through Stages on"
-                " earlier threads to avoid a latency mismatch and thread blocking.\n"
-                "A Bypass Stage can be added on an earlier thread if no additional DSP is needed." + input_msg)
+                raise RuntimeError(
+                    f"\nAll stage inputs to {type(self).__name__} (label={self.label})"
+                    " must cross the same number of threads.\n"
+                    f"Currently, inputs cross {thread_crossings} threads.\nInputs with less than "
+                    f"{max(thread_crossings)} thread crossings must pass through Stages on"
+                    " earlier threads to avoid a latency mismatch and thread blocking.\n"
+                    "A Bypass Stage can be added on an earlier thread if no additional DSP is needed."
+                    + input_msg
+                )
 
-            self.crossings = list(set(inputs.edges[0].crossings))
+            self.crossings = list(set(self.i.edges[0].crossings))  # pyright: ignore checked above
 
     def __init_subclass__(cls) -> None:
         """Add all subclasses of Stage to a global list for querying."""

--- a/python/audio_dsp/design/thread.py
+++ b/python/audio_dsp/design/thread.py
@@ -2,8 +2,10 @@
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 """Contains classes for adding a thread to the DSP pipeline."""
 
-from .composite_stage import CompositeStage
-from .stage import Stage, StageOutputList, find_config
+from typing import Type
+
+from audio_dsp.design.composite_stage import CompositeStage, _StageOrComposite
+from audio_dsp.design.stage import Stage, StageOutputList, find_config
 
 
 class DSPThreadStage(Stage):
@@ -64,3 +66,22 @@ class Thread(CompositeStage):
     def add_thread_stage(self):
         """Add to this thread the stage which manages thread level commands."""
         self.thread_stage = self.stage(DSPThreadStage, StageOutputList(), label=f"thread{self.id}")
+
+    def stage(
+        self,
+        stage_type: Type[_StageOrComposite],
+        inputs: StageOutputList,
+        label: str | None = None,
+        **kwargs,
+    ) -> _StageOrComposite:
+        """ 
+        Create a new stage or composite stage and
+        register it with this composite stage.
+
+        This is a wrapper around :func:`audio_dsp.design.composite_stage.stage`
+        but adds a thread crossing counter.
+        """
+        for i in inputs.edges:
+            i.crossings.append(self.id)
+        stage = super().stage(stage_type, inputs, label, **kwargs)
+        return stage

--- a/python/audio_dsp/design/thread.py
+++ b/python/audio_dsp/design/thread.py
@@ -74,7 +74,7 @@ class Thread(CompositeStage):
         label: str | None = None,
         **kwargs,
     ) -> _StageOrComposite:
-        """ 
+        """
         Create a new stage or composite stage and
         register it with this composite stage.
 
@@ -82,6 +82,7 @@ class Thread(CompositeStage):
         but adds a thread crossing counter.
         """
         for i in inputs.edges:
-            i.crossings.append(self.id)
+            if i:
+                i.crossings.append(self.id)
         stage = super().stage(stage_type, inputs, label, **kwargs)
         return stage

--- a/test/pipeline/test_thread_crossings.py
+++ b/test/pipeline/test_thread_crossings.py
@@ -1,19 +1,27 @@
+# Copyright 2025 XMOS LIMITED.
+# This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
+import pytest
 from audio_dsp.design.pipeline import Pipeline, generate_dsp_main
 from audio_dsp.stages import *
 
+
 def test_bad_pipelines():
-    p, inputs = Pipeline.begin(2, fs=48000)
+    with pytest.raises(RuntimeError) as excinfo:
+        p, inputs = Pipeline.begin(2, fs=48000)
 
-    # inputs[1] is not used on thread 0
-    x1 = p.stage(Biquad, inputs[0], 'bq1')
+        # inputs[1] is not used on thread 0
+        x1 = p.stage(Biquad, inputs[0], 'bq1')
 
-    p.next_thread()
+        p.next_thread()
 
-    # inputs[1] first used on thread 1
-    x = p.stage(Biquad, x1 + inputs[1], 'bq2')
+        # inputs[1] first used on thread 1
+        x = p.stage(Biquad, x1 + inputs[1], 'bq2')
 
-    p.set_outputs(x)
+        p.set_outputs(x)
+    
+    assert "must cross the same number of threads" in str(excinfo.value)
+
 
 def test_good_pipelines():
 
@@ -28,6 +36,7 @@ def test_good_pipelines():
     x = p.stage(Biquad, x1 + x2, 'bq2')
 
     p.set_outputs(x)
+
 
 def test_parallel_pipelines():
 
@@ -89,50 +98,48 @@ def test_good_complex():
 
     p.set_outputs(usb0 + usb1 + mon0 + mon1)
 
-    return p
-
 
 def test_bad_complex():
-    
-    # 4 inputs
-    p, i = Pipeline.begin(4, fs=48000)
+    with pytest.raises(RuntimeError) as excinfo:
+        # 4 inputs
+        p, i = Pipeline.begin(4, fs=48000)
 
-    mic1 = p.stage(Fork, i[2], count=3).forks
-    mic2 = p.stage(Fork, i[3], count=3).forks
+        mic1 = p.stage(Fork, i[2], count=3).forks
+        mic2 = p.stage(Fork, i[3], count=3).forks
 
-    p.stage(EnvelopeDetectorRMS, mic1[0], "edr1")
-    p.stage(EnvelopeDetectorRMS, mic2[0], "edr2")
+        p.stage(EnvelopeDetectorRMS, mic1[0], "edr1")
+        p.stage(EnvelopeDetectorRMS, mic2[0], "edr2")
 
-    mic_mono = p.stage(Adder, mic1[1] + mic2[1], "adder1")
-    mic_mono = p.stage(Fork, mic_mono, count=3).forks
-    mic_dnr = p.stage(NoiseSuppressorExpander, mic_mono[0], "ns")
-    peq1 = p.stage(CascadedBiquads, mic_dnr, "peq1")
-    sw_1 = p.stage(SwitchStereo, mic_mono[1] + mic_mono[2] + mic1[2] + mic2[2], "sw_1")
+        mic_mono = p.stage(Adder, mic1[1] + mic2[1], "adder1")
+        mic_mono = p.stage(Fork, mic_mono, count=3).forks
+        mic_dnr = p.stage(NoiseSuppressorExpander, mic_mono[0], "ns")
+        peq1 = p.stage(CascadedBiquads, mic_dnr, "peq1")
+        sw_1 = p.stage(SwitchStereo, mic_mono[1] + mic_mono[2] + mic1[2] + mic2[2], "sw_1")
 
-    p.next_thread()
-    mic_peq = p.stage(Fork, peq1, count=3).forks
-    peq2 = p.stage(CascadedBiquads, mic_peq[2], "peq2")
-    mic_rv = p.stage(Fork, peq2).forks
-    
-    p.next_thread()
-    mic_rv = p.stage(ReverbPlateStereo, mic_rv[0] + mic_rv[1], "reverb")
-    cfs1 = p.stage(CrossfaderStereo, mic_peq[0] + mic_peq[1] + mic_rv[0] + mic_rv[1], "cfs1")
-    rv_sw = p.stage(SwitchStereo, cfs1 + sw_1, "reverb_sw")
-    vol1 = p.stage(VolumeControl, rv_sw[0], "vol1")
-    vol2 = p.stage(VolumeControl, rv_sw[1], "vol2")
+        p.next_thread()
+        mic_peq = p.stage(Fork, peq1, count=3).forks
+        peq2 = p.stage(CascadedBiquads, mic_peq[2], "peq2")
+        mic_rv = p.stage(Fork, peq2).forks
+        
+        p.next_thread()
+        mic_rv = p.stage(ReverbPlateStereo, mic_rv[0] + mic_rv[1], "reverb")
+        cfs1 = p.stage(CrossfaderStereo, mic_peq[0] + mic_peq[1] + mic_rv[0] + mic_rv[1], "cfs1")
+        rv_sw = p.stage(SwitchStereo, cfs1 + sw_1, "reverb_sw")
+        vol1 = p.stage(VolumeControl, rv_sw[0], "vol1")
+        vol2 = p.stage(VolumeControl, rv_sw[1], "vol2")
 
-    p.next_thread()
-    usb_play, usb_mon = p.stage(Fork, i[:2]).forks
-    usb_play = p.stage(VolumeControl, usb_play, "vol3")
-    mic_play, mic_mon = p.stage(Fork, vol1 + vol2).forks
-    usb0 = p.stage(Adder, usb_play[0] + mic_play[0], "adder2")
-    usb1 = p.stage(Adder, usb_play[1] + mic_play[1], "adder3")
-    cfs2 = p.stage(CrossfaderStereo, usb_mon[0] + usb_mon[1] + mic_mon[0] + mic_mon[1], "cfs2")
-    mon0, mon1 = p.stage(VolumeControl, cfs2, "vol4")
+        p.next_thread()
+        usb_play, usb_mon = p.stage(Fork, i[:2]).forks
+        usb_play = p.stage(VolumeControl, usb_play, "vol3")
+        mic_play, mic_mon = p.stage(Fork, vol1 + vol2).forks
+        usb0 = p.stage(Adder, usb_play[0] + mic_play[0], "adder2")
+        usb1 = p.stage(Adder, usb_play[1] + mic_play[1], "adder3")
+        cfs2 = p.stage(CrossfaderStereo, usb_mon[0] + usb_mon[1] + mic_mon[0] + mic_mon[1], "cfs2")
+        mon0, mon1 = p.stage(VolumeControl, cfs2, "vol4")
 
-    p.set_outputs(usb0 + usb1 + mon0 + mon1)
+        p.set_outputs(usb0 + usb1 + mon0 + mon1)
 
-    return p
+    assert "must cross the same number of threads" in str(excinfo.value)
 
 if __name__ == "__main__":
     # test_bad_pipelines()

--- a/test/pipeline/test_thread_crossings.py
+++ b/test/pipeline/test_thread_crossings.py
@@ -1,0 +1,140 @@
+
+from audio_dsp.design.pipeline import Pipeline, generate_dsp_main
+from audio_dsp.stages import *
+
+def test_bad_pipelines():
+    p, inputs = Pipeline.begin(2, fs=48000)
+
+    # inputs[1] is not used on thread 0
+    x1 = p.stage(Biquad, inputs[0], 'bq1')
+
+    p.next_thread()
+
+    # inputs[1] first used on thread 1
+    x = p.stage(Biquad, x1 + inputs[1], 'bq2')
+
+    p.set_outputs(x)
+
+def test_good_pipelines():
+
+    p, inputs = Pipeline.begin(2, fs=48000)
+
+    # both inputs are not used on this thread
+    x1 = p.stage(Biquad, inputs[0], 'bq1')
+    x2 = p.stage(Bypass, inputs[1], 'by1')
+
+    p.next_thread()
+
+    x = p.stage(Biquad, x1 + x2, 'bq2')
+
+    p.set_outputs(x)
+
+def test_parallel_pipelines():
+
+    p, inputs = Pipeline.begin(2, fs=48000)
+
+    x1 = p.stage(Biquad, inputs[0], 'bq1')
+    p.next_thread()
+
+    x2 = p.stage(Bypass, inputs[1], 'by1')
+    p.next_thread()
+
+    # x1 and x2 have both crossed 1 thread already
+    x = p.stage(Biquad, x1 + x2, 'bq2')
+
+    p.set_outputs(x)
+
+
+def test_good_complex():
+
+    # 4 inputs
+    p, i = Pipeline.begin(4, fs=48000)
+
+    mic1 = p.stage(Fork, i[2], count=3).forks
+    mic2 = p.stage(Fork, i[3], count=3).forks
+
+    p.stage(EnvelopeDetectorRMS, mic1[0], "edr1")
+    p.stage(EnvelopeDetectorRMS, mic2[0], "edr2")
+
+    mic_mono = p.stage(Adder, mic1[1] + mic2[1], "adder1")
+    mic_mono = p.stage(Fork, mic_mono, count=3).forks
+    mic_dnr = p.stage(NoiseSuppressorExpander, mic_mono[0], "ns")
+    peq1 = p.stage(CascadedBiquads, mic_dnr, "peq1")
+    sw_1 = p.stage(SwitchStereo, mic_mono[1] + mic_mono[2] + mic1[2] + mic2[2], "sw_1")
+    i_bypass = p.stage(Bypass, i[:2])
+
+    p.next_thread()
+    mic_peq = p.stage(Fork, peq1, count=3).forks
+    peq2 = p.stage(CascadedBiquads, mic_peq[2], "peq2")
+    mic_rv = p.stage(Fork, peq2).forks
+    i_bypass = p.stage(Bypass, i_bypass)
+    sw_1 = p.stage(Bypass, sw_1)
+
+    p.next_thread()
+    mic_rv = p.stage(ReverbPlateStereo, mic_rv[0] + mic_rv[1], "reverb")
+    cfs1 = p.stage(CrossfaderStereo, mic_peq[0] + mic_peq[1] + mic_rv[0] + mic_rv[1], "cfs1")
+    rv_sw = p.stage(SwitchStereo, cfs1 + sw_1, "reverb_sw")
+    vol1 = p.stage(VolumeControl, rv_sw[0], "vol1")
+    vol2 = p.stage(VolumeControl, rv_sw[1], "vol2")
+    i_bypass = p.stage(Bypass, i_bypass)
+
+    p.next_thread()
+    usb_play, usb_mon = p.stage(Fork, i_bypass).forks
+    usb_play = p.stage(VolumeControl, usb_play, "vol3")
+    mic_play, mic_mon = p.stage(Fork, vol1 + vol2).forks
+    usb0 = p.stage(Adder, usb_play[0] + mic_play[0], "adder2")
+    usb1 = p.stage(Adder, usb_play[1] + mic_play[1], "adder3")
+    cfs2 = p.stage(CrossfaderStereo, usb_mon[0] + usb_mon[1] + mic_mon[0] + mic_mon[1], "cfs2")
+    mon0, mon1 = p.stage(VolumeControl, cfs2, "vol4")
+
+    p.set_outputs(usb0 + usb1 + mon0 + mon1)
+
+    return p
+
+
+def test_bad_complex():
+    
+    # 4 inputs
+    p, i = Pipeline.begin(4, fs=48000)
+
+    mic1 = p.stage(Fork, i[2], count=3).forks
+    mic2 = p.stage(Fork, i[3], count=3).forks
+
+    p.stage(EnvelopeDetectorRMS, mic1[0], "edr1")
+    p.stage(EnvelopeDetectorRMS, mic2[0], "edr2")
+
+    mic_mono = p.stage(Adder, mic1[1] + mic2[1], "adder1")
+    mic_mono = p.stage(Fork, mic_mono, count=3).forks
+    mic_dnr = p.stage(NoiseSuppressorExpander, mic_mono[0], "ns")
+    peq1 = p.stage(CascadedBiquads, mic_dnr, "peq1")
+    sw_1 = p.stage(SwitchStereo, mic_mono[1] + mic_mono[2] + mic1[2] + mic2[2], "sw_1")
+
+    p.next_thread()
+    mic_peq = p.stage(Fork, peq1, count=3).forks
+    peq2 = p.stage(CascadedBiquads, mic_peq[2], "peq2")
+    mic_rv = p.stage(Fork, peq2).forks
+    
+    p.next_thread()
+    mic_rv = p.stage(ReverbPlateStereo, mic_rv[0] + mic_rv[1], "reverb")
+    cfs1 = p.stage(CrossfaderStereo, mic_peq[0] + mic_peq[1] + mic_rv[0] + mic_rv[1], "cfs1")
+    rv_sw = p.stage(SwitchStereo, cfs1 + sw_1, "reverb_sw")
+    vol1 = p.stage(VolumeControl, rv_sw[0], "vol1")
+    vol2 = p.stage(VolumeControl, rv_sw[1], "vol2")
+
+    p.next_thread()
+    usb_play, usb_mon = p.stage(Fork, i[:2]).forks
+    usb_play = p.stage(VolumeControl, usb_play, "vol3")
+    mic_play, mic_mon = p.stage(Fork, vol1 + vol2).forks
+    usb0 = p.stage(Adder, usb_play[0] + mic_play[0], "adder2")
+    usb1 = p.stage(Adder, usb_play[1] + mic_play[1], "adder3")
+    cfs2 = p.stage(CrossfaderStereo, usb_mon[0] + usb_mon[1] + mic_mon[0] + mic_mon[1], "cfs2")
+    mon0, mon1 = p.stage(VolumeControl, cfs2, "vol4")
+
+    p.set_outputs(usb0 + usb1 + mon0 + mon1)
+
+    return p
+
+if __name__ == "__main__":
+    # test_bad_pipelines()
+    test_bad_complex()
+    test_good_complex()


### PR DESCRIPTION
example error:
```
RuntimeError:
All stage inputs to SwitchStereo (label=reverb_sw) must cross the same number of threads.
Currently, inputs cross [3, 3, 2, 2] threads.
Inputs with less than 3 thread crossings must pass through Stages on earlier threads to avoid a latency mismatch and thread blocking.
A Bypass Stage can be added on an earlier thread if no additional DSP is needed.
Input 0 crosses threads {0, 1, 2}.
Input 1 crosses threads {0, 1, 2}.
Input 2 crosses threads {0, 2}.
Input 3 crosses threads {0, 2}.